### PR TITLE
FIx insiders detection

### DIFF
--- a/common/utils.js
+++ b/common/utils.js
@@ -4,7 +4,7 @@ const path = require("path");
 const fs = require("fs");
 
 let vsCodeUserSettingsPath;
-let isInsiders = /Insiders/.test(process.argv0);
+let isInsiders = /insiders/i.test(process.argv0);
 let CodeDir = isInsiders?'Code - Insiders':'Code';
 switch (os.type()) {
     case "Darwin":


### PR DESCRIPTION
Hi I found that in new versions of the vscode insiders compilation the extension did not work due to the capital letter. In my opinion, would better use the case-insensitive flag to fix this so It will work in both cases