### PR TITLE
Fix ability to edit snippets while using remote WSL/SSH

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
 		"onView:snippetExplorer"
 	],
 	"main": "./extension",
+	"extensionKind": ["ui"],
 	"contributes": {
 		"commands": [
 			{


### PR DESCRIPTION
When developing on remotes like SSH and WSL with VSCode, then extensions can decide to run on the host or on the remote filesystem. The snippets are only available on the host though, they are not accessible on the remote host filesystem.

Where the extension is running can be controlled with [extensionKind](https://code.visualstudio.com/api/advanced-topics/remote-extensions#incorrect-execution-location), settable in package.json.

In the extensionKind documentation is written that extensions which do not declare this option are workspace-extensions by default (running on the remote host), making snippets inaccessible and so printing

```
ENOENT: no such file or directory,
scandir '/home/limdi/.config/Code - Insiders/User/snippets'
```

Converting the extension to an ui-extension (not having to install it on the remote) fixes this while developing with remotes.