### PR TITLE
Fixes: skylark snippet creation

### DIFF
--- a/common/utils.js
+++ b/common/utils.js
@@ -76,9 +76,7 @@ const utils = {
         // reference https://github.com/Microsoft/vscode/issues/2871#issuecomment-338364014
         var langConfigFilepath = null;
         for (const _ext of vscode.extensions.all) {
-            // All vscode default extensions ids starts with "vscode."
             if (
-                _ext.id.startsWith("vscode.") &&
                 _ext.packageJSON.contributes &&
                 _ext.packageJSON.contributes.languages
             ) {


### PR DESCRIPTION
Skylark snippets do by default get auto-formatted here on save. This formatting inserts a space between our `@prefix` and `@description` tags => `@ prefix` and `@ description`. This is why skylark rules were not creatable through easy-snippet.

This change permits this automatically-inserted space between @ and prefix. And so fixes skylark snippet creation.